### PR TITLE
Fix import/export on *nix systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 Blender PKG Add-On
-Version 1.02
-March 11th 2022
+Version 1.03
+
+31st July 2023
 
 Created by Dummiesman
 

--- a/io_scene_pkg/__init__.py
+++ b/io_scene_pkg/__init__.py
@@ -10,7 +10,7 @@
 bl_info = {
     "name": "Angel Studios PKG Format",
     "author": "Dummiesman",
-    "version": (1, 0, 0),
+    "version": (1, 0, 3),
     "blender": (2, 83, 0),
     "location": "File > Import-Export",
     "description": "Import-Export PKG files",

--- a/io_scene_pkg/binary_helper.py
+++ b/io_scene_pkg/binary_helper.py
@@ -16,7 +16,7 @@ import io_scene_pkg.common_helpers as helper
 # READ #
 ########
 def read_angel_string(file):
-    str_len = struct.unpack('B', file.read(1))[0]
+    str_len = struct.unpack('<B', file.read(1))[0]
     if str_len == 0:
         return ''
     else:
@@ -52,7 +52,7 @@ def read_color4f(file):
 
 
 def read_color4d(file):
-    c4d = struct.unpack('BBBB', file.read(4))
+    c4d = struct.unpack('<BBBB', file.read(4))
     return [c4d[0]/255, c4d[1]/255, c4d[2]/255, c4d[3]/255]
 
 

--- a/io_scene_pkg/binary_helper.py
+++ b/io_scene_pkg/binary_helper.py
@@ -108,11 +108,11 @@ def write_matrix3x4(file, matrix):
 
 def write_angel_string(file, strng):
     if strng is not None and len(strng) > 0:
-        file.write(struct.pack('B', len(strng)+1))
+        file.write(struct.pack('<B', len(strng)+1))
         file.write(bytes(strng, 'UTF-8'))
         file.write(bytes('\x00', 'UTF-8'))
     else:
-        file.write(struct.pack('B', 0))
+        file.write(struct.pack('<B', 0))
 
 
 def write_float2(file, data):
@@ -128,7 +128,7 @@ def write_color4d(file, color, alpha=1):
     g = min(255, int(color[1] * 255))
     b = min(255, int(color[2] * 255))
     a = min(255, int(alpha * 255))
-    file.write(struct.pack('BBBB', r, g, b, a))
+    file.write(struct.pack('<BBBB', r, g, b, a))
 
 
 def write_color4f(file, color, alpha=1):
@@ -138,4 +138,4 @@ def write_color4f(file, color, alpha=1):
 def write_file_header(file, name, length=0):
     file.write(bytes('FILE', 'utf-8'))
     write_angel_string(file, name)
-    file.write(struct.pack('L', length))
+    file.write(struct.pack('<L', length))

--- a/io_scene_pkg/export_helper.py
+++ b/io_scene_pkg/export_helper.py
@@ -185,10 +185,10 @@ def bounds(obj):
 
 def write_matrix_standard(object, file):
     bnds = bounds(object)
-    file.write(struct.pack('fff', *helper.convert_vecspace_to_mm2((bnds.x.min * -1, bnds.y.min, bnds.z.min)))) # have to do * -1 for some reason
-    file.write(struct.pack('fff', *helper.convert_vecspace_to_mm2((bnds.x.max * -1, bnds.y.max, bnds.z.max)))) # have to do * -1 for some reason
-    file.write(struct.pack('fff', *helper.convert_vecspace_to_mm2(object.location))) # write this twice. one is pivot and one is origin
-    file.write(struct.pack('fff', *helper.convert_vecspace_to_mm2(object.location)))
+    file.write(struct.pack('<fff', *helper.convert_vecspace_to_mm2((bnds.x.min * -1, bnds.y.min, bnds.z.min)))) # have to do * -1 for some reason
+    file.write(struct.pack('<fff', *helper.convert_vecspace_to_mm2((bnds.x.max * -1, bnds.y.max, bnds.z.max)))) # have to do * -1 for some reason
+    file.write(struct.pack('<fff', *helper.convert_vecspace_to_mm2(object.location))) # write this twice. one is pivot and one is origin
+    file.write(struct.pack('<fff', *helper.convert_vecspace_to_mm2(object.location)))
 
                                            
 def write_matrix(meshname, object, pkg_path):

--- a/io_scene_pkg/export_pkg.py
+++ b/io_scene_pkg/export_pkg.py
@@ -202,7 +202,7 @@ def export_xrefs(file, selected_only):
         bin.write_file_header(file, "xrefs")
         num_xrefs = 0
         xref_num_offset = file.tell()
-        file.write(struct.pack('L', 0))
+        file.write(struct.pack('<L', 0))
         for obj in xref_objects:
             num_xrefs += 1
             #write matrix
@@ -217,13 +217,13 @@ def export_xrefs(file, selected_only):
                 
         file_length = file.tell() - xref_num_offset
         file.seek(xref_num_offset - 4, 0)
-        file.write(struct.pack('LL', file_length, num_xrefs))
+        file.write(struct.pack('<LL', file_length, num_xrefs))
         file.seek(0, 2)
 
 
 def export_offset(file):
     bin.write_file_header(file, "offset", 12)
-    file.write(struct.pack('fff', 0, 0, 0))
+    file.write(struct.pack('<fff', 0, 0, 0))
 
 
 def export_shaders(file, context, type="byte"):
@@ -251,7 +251,7 @@ def export_shaders(file, context, type="byte"):
     shaders_per_paintjob = len(material_remap_table)
     
     # write header
-    file.write(struct.pack('LL', shadertype_raw, shaders_per_paintjob))
+    file.write(struct.pack('<LL', shadertype_raw, shaders_per_paintjob))
     
     # write material sets
     ordered_material_remap = sorted(material_remap_table.items(), key =lambda x: x[1])
@@ -284,7 +284,7 @@ def export_shaders(file, context, type="byte"):
     # write file length
     shaders_file_length = file.tell() - shaders_data_offset
     file.seek(shaders_data_offset - 4)
-    file.write(struct.pack('L', shaders_file_length))
+    file.write(struct.pack('<L', shaders_file_length))
     file.seek(0, 2)
 
 
@@ -339,7 +339,7 @@ def export_geometry(file, meshlist, options):
             export_helper.write_matrix(obj.name, obj, pkg_path)
 
         # write mesh data header
-        file.write(struct.pack('LLLLL', num_sections, total_verts, total_faces, num_sections, FVF_FLAGS.value))
+        file.write(struct.pack('<LLLLL', num_sections, total_verts, total_faces, num_sections, FVF_FLAGS.value))
 
         # write sections
         cur_material_index = -1
@@ -363,10 +363,10 @@ def export_geometry(file, meshlist, options):
             shader_offset = material_remap_table[real_material.name]
             
             # write strip to file
-            file.write(struct.pack('HHL', num_strips, section_flags, shader_offset))
+            file.write(struct.pack('<HHL', num_strips, section_flags, shader_offset))
             strip_primType = 3
             strip_vertices = len(cmtl_verts)
-            file.write(struct.pack('LL', strip_primType, strip_vertices))
+            file.write(struct.pack('<LL', strip_primType, strip_vertices))
             
             # write vertices
             for cv in range(len(cmtl_verts)):
@@ -384,9 +384,9 @@ def export_geometry(file, meshlist, options):
             
             # write indices
             strip_indices_len = int(len(cmtl_indices) * 3)
-            file.write(struct.pack('L', strip_indices_len))
+            file.write(struct.pack('<L', strip_indices_len))
             for ply in cmtl_indices:
-                file.write(struct.pack('HHH', ply[0], ply[1], ply[2]))
+                file.write(struct.pack('<HHH', ply[0], ply[1], ply[2]))
         
         # clean up temp_mesh
         bm.free()
@@ -394,7 +394,7 @@ def export_geometry(file, meshlist, options):
         # write FILE length
         file_data_length = file.tell() - file_data_start_offset
         file.seek(file_data_start_offset - 4)
-        file.write(struct.pack('L', file_data_length))
+        file.write(struct.pack('<L', file_data_length))
         file.seek(0, 2)
 
 

--- a/io_scene_pkg/import_helper.py
+++ b/io_scene_pkg/import_helper.py
@@ -45,7 +45,7 @@ def find_matrix(meshname, pkg_path):
     
     if find_path is not None:
         mtxfile = open(find_path, 'rb')
-        mtx_info = struct.unpack('ffffffffffff', mtxfile.read(48))
+        mtx_info = struct.unpack('<ffffffffffff', mtxfile.read(48))
         
         mtx_min = helper.convert_vecspace_to_blender((mtx_info[0], mtx_info[1], mtx_info[2]))
         mtx_max = helper.convert_vecspace_to_blender((mtx_info[3], mtx_info[4], mtx_info[5]))

--- a/io_scene_pkg/import_pkg.py
+++ b/io_scene_pkg/import_pkg.py
@@ -113,7 +113,7 @@ def read_xrefs(file):
     scn = bpy.context.scene
 
     # read xrefs
-    num_xrefs = struct.unpack('L', file.read(4))[0]
+    num_xrefs = struct.unpack('<L', file.read(4))[0]
     for num in range(num_xrefs):
         # read matrix
         mtx = bin.read_matrix3x4(file)
@@ -157,7 +157,7 @@ def read_geometry_file(file, meshname):
     bpy.ops.object.mode_set(mode='EDIT', toggle=False)
     
     # read geometry FILE data
-    num_sections, num_vertices_tot, num_indices_tot, num_sections_dupe, fvf = struct.unpack('5L', file.read(20))
+    num_sections, num_vertices_tot, num_indices_tot, num_sections_dupe, fvf = struct.unpack('<5L', file.read(20))
     FVF_FLAGS = FVF(fvf)
 
     # mesh data holders
@@ -179,7 +179,7 @@ def read_geometry_file(file, meshname):
         FLAG_compact_strips = ((strip_flags & (1 << 8)) != 0)
 
         # get material, and add it to the objects material list
-        shader_offset = struct.unpack('H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('L', file.read(4))[0]
+        shader_offset = struct.unpack('<H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('<L', file.read(4))[0]
         
         # do we have this material?
         if bpy.data.materials.get(str(shader_offset)) is None:
@@ -192,8 +192,8 @@ def read_geometry_file(file, meshname):
         # read strips
         for strip in range(num_strips):
             # read
-            prim_type = struct.unpack('H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('L', file.read(4))[0] # seek past primtype
-            num_vertices =  struct.unpack('H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('L', file.read(4))[0]
+            prim_type = struct.unpack('<H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('<L', file.read(4))[0] # seek past primtype
+            num_vertices =  struct.unpack('<H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('<L', file.read(4))[0]
 
             # read vertices
             for i in range(num_vertices):
@@ -229,14 +229,14 @@ def read_geometry_file(file, meshname):
                     
                     
             # read indices and build mesh
-            num_indices = struct.unpack('H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('L', file.read(4))[0]
+            num_indices = struct.unpack('<H', file.read(2))[0] if FLAG_compact_strips else struct.unpack('<L', file.read(4))[0]
 
             triangle_data = None
             if FLAG_compact_strips and prim_type == 4:
-             tristrip_data = struct.unpack(str(num_indices) + 'H', file.read(2 * num_indices))
+             tristrip_data = struct.unpack('<' + str(num_indices) + 'H', file.read(2 * num_indices))
              triangle_data = import_helper.convert_triangle_strips(tristrip_data)
             else:
-             triangle_data = struct.unpack(str(num_indices) + 'H', file.read(2 * num_indices))
+             triangle_data = struct.unpack('<' + str(num_indices) + 'H', file.read(2 * num_indices))
 
             for i in range(0, len(triangle_data), 3):
               tri_indices = triangle_data[i:i+3]
@@ -349,7 +349,7 @@ def load_pkg(filepath,
 
         # found a proper FILE header
         file_name = bin.read_angel_string(file)
-        file_length = 0 if pkg_version_id == 2 else struct.unpack('L', file.read(4))[0]
+        file_length = 0 if pkg_version_id == 2 else struct.unpack('<L', file.read(4))[0]
         
         # Angel released a very small batch of corrupt PKG files
         # this is here just in case someone tries to import one

--- a/io_scene_pkg/shader_set.py
+++ b/io_scene_pkg/shader_set.py
@@ -98,7 +98,7 @@ class Shader:
 
 class ShaderSet:
     def read(self, file):
-        shadertype_raw, shaders_per_variant = struct.unpack('2L', file.read(8))
+        shadertype_raw, shaders_per_variant = struct.unpack('<2L', file.read(8))
         
         self.type = "float"
         self.num_variants = shadertype_raw

--- a/io_scene_pkg/shader_set.py
+++ b/io_scene_pkg/shader_set.py
@@ -34,7 +34,7 @@ class Shader:
             bin.write_color4f(file, self.specular_color)
             bin.write_color4f(file, self.emissive_color)
             
-        file.write(struct.pack('f', self.shininess))
+        file.write(struct.pack('<f', self.shininess))
         
     def read(self, file, type):
         type = type if type is not None else self.type


### PR DESCRIPTION
_I have:_

- Set `struct.unpack` and `struct.pack` to always use little-endian and standard sizes.
- Created a basic case-insensitive file loader.
- Added a `.gitignore`


_Reasoning:_

- Errors such as `unpack requires a buffer of x bytes` are due to differences in systems' native sizes for types. For example, unsigned longs on Windows are 4 bytes but on other sytems they are 8. Thus, we should use the standard sizing and not the native system sizing as this isn't portable.
  - Realistically, the only systems this will be run on are x86, x86_64, or ARM which are all modern architectures using little-endian encoding, so I've chosen to force little endian everywhere.

- The importing works fine on Windows because, despite NTFS being case-sensitive, functionally it isn't for software. To make this portable we should do thorough checks. I've chosen to do the simplest method here and `listdir` the directory to search and compare lowercased filenames.

- Added a gitignore because, while testing this repo, I ended up with lots of `.pyc` files which we don't want in the repo.

_Closes (I think!):_

- #2
- #3